### PR TITLE
Added FASTCONNECT setting and behaviour.

### DIFF
--- a/client/sguil.tk
+++ b/client/sguil.tk
@@ -157,6 +157,7 @@ set CUR_SEL_FRAME(name) 0
 set COUNTER 0
 set SEARCHFRAME 1
 set SELECT_LIMIT 1000
+set FASTCONNECT 0
 set WHOISLIST "none"
 set ES_PROFILE(host) {https://192.168.8.10}
 set ES_PROFILE(user) {}
@@ -1871,7 +1872,7 @@ proc CreateSensorCheckButton { winName sensorName userList } {
 #             want to monitor.
 #
 proc SensorList { sensorList } {
-  global MONITORFLAG sensorSelectArray VERSION selectAllButton
+  global MONITORFLAG sensorSelectArray VERSION selectAllButton FASTCONNECT
   set sensorSelectWindow [toplevel .sensorSelectWindow -background white]
   wm title $sensorSelectWindow "$VERSION"
   set welcomeFrame [frame $sensorSelectWindow.welcomeFrame -borderwidth 1 -background black]
@@ -1927,8 +1928,13 @@ proc SensorList { sensorList } {
     set exitButton [button $actionButtonFrame.exitButton -text "Exit" -command "CleanExit"]
     pack $selectAllButton $monitorButton $exitButton -side left -padx 10 -pady 10
   pack $actionButtonFrame -side top
-  # Don't move on until we select the sensors
-  tkwait window $sensorSelectWindow
+  if { !$FASTCONNECT } {
+    # Don't move on until we select the sensors
+    tkwait window $sensorSelectWindow
+  } else {
+    SelectAllSensors
+    MonitorSensors $sensorSelectWindow
+  }
   set MONITORFLAG 1
 }
 proc MonitorSensors { winName } {
@@ -3462,8 +3468,11 @@ bind $soundStatus <Button-1> {
 #################### Connect To The Server ##############################
 
 set CONNECTED 0
-# Get login and sguild host info
-GetUserName
+
+if { !$FASTCONNECT || $USERNAME == "" || $PASSWD == "" || $SERVERPORT == "" || $SERVERHOST == "" } {
+  # Get login and sguild host info
+  GetUserName
+}
 
 while { $USERNAME == "" } {
 


### PR DESCRIPTION
Added FASTCONNECT setting. If set to 1 (default 0), it will cause sguil
to not ask for user, pass and such if already set in the config. It will
also select all sensors automatically, and then connect to the server.

Usefull for people that only connect to one server.
